### PR TITLE
Add a docstring to check!

### DIFF
--- a/src/danieroux/type/transcriptor.clj
+++ b/src/danieroux/type/transcriptor.clj
@@ -11,7 +11,7 @@
 
 (def ^:dynamic *asserts*)
 
-(defmacro check!!
+(defmacro check!
   "Delegate to `transcriptor/check!` and on success, mark it as a passing assert.
 
   This only exists for more granular reporting:

--- a/src/danieroux/type/transcriptor.clj
+++ b/src/danieroux/type/transcriptor.clj
@@ -11,21 +11,27 @@
 
 (def ^:dynamic *asserts*)
 
-(defmacro check!
+(defmacro check!!
   "Delegate to `transcriptor/check!` and on success, mark it as a passing assert.
 
   This only exists for more granular reporting:
 
   You could also just use `transcriptor/check!` directly, in which case one .repl file will
   count as one test, with no assertions."
-  ([spec]
-   `(check! ~spec *1))
-  ([spec v]
-   `(do
-      (xr/check! ~spec ~v)
-      (when (bound? #'*asserts*)
-        (swap! *asserts* inc))
-      (t/do-report {:type :pass}))))
+  {:arglists '([docstring? spec]
+               [docstring? spec v])}
+  ([& args]
+   (let [has-doc? (string? (first args))
+         args' (if has-doc? (rest args) args)
+         has-v? (> (count args') 1)
+         [spec v] args']
+     (if-not has-v?
+       `(check! ~spec *1)
+       `(do
+          (xr/check! ~spec ~v)
+          (when (bound? #'*asserts*)
+            (swap! *asserts* inc))
+          (t/do-report {:type :pass}))))))
 
 (defmethod kaocha.testable/-load :danieroux.type/transcriptor [testable]
   (let [test-paths (:kaocha/test-paths testable)


### PR DESCRIPTION
The purpose of this is to add a doc string as the first argument to the check!

This allows for adding a more definite description to a test vs wrapping a test in a function or simply adding a comment.

```clojure
(check!
  "Something something test"
  :some/spec
  "a value")
```

The doc string serves no purpose other than informing the reader about the intention of the test.

This change is backwards compatible, however the function signature does diverge from that of transcriptor's check! function. If this is undesirable, perhaps a second function can added that takes a doc string and wraps the check! macro. This will leave the check! macro un touched.

- [x] I want check! with a doc string!!
- [ ] I want a new function. Perhaps check!!.

Note I will do more extensive testing once a preferred path has been selected. 